### PR TITLE
Fast dragging bug and a end dragging method

### DIFF
--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -87,7 +87,7 @@ public class LPRTableView: UITableView {
 	}
 	
 	private func initialize() {
-		longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: "_longPress:")
+		longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(LPRTableView._longPress(_:)))
 		addGestureRecognizer(longPressGestureRecognizer)
 	}
 	
@@ -96,7 +96,7 @@ public class LPRTableView: UITableView {
 extension LPRTableView {
 	
 	private func canMoveRowAt(indexPath indexPath: NSIndexPath) -> Bool {
-		return (dataSource?.respondsToSelector("tableView:canMoveRowAtIndexPath:") == false) || (dataSource?.tableView?(self, canMoveRowAtIndexPath: indexPath) == true)
+		return (dataSource?.respondsToSelector(#selector(UITableViewDataSource.tableView(_:canMoveRowAtIndexPath:))) == false) || (dataSource?.tableView?(self, canMoveRowAtIndexPath: indexPath) == true)
 	}
 	
 	private func cancelGesture() {
@@ -177,7 +177,7 @@ extension LPRTableView {
 					initialIndexPath = indexPath
 					
 					// Enable scrolling for cell.
-					scrollDisplayLink = CADisplayLink(target: self, selector: "_scrollTableWithCell:")
+					scrollDisplayLink = CADisplayLink(target: self, selector: #selector(LPRTableView._scrollTableWithCell(_:)))
 					scrollDisplayLink?.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)
 				}
 			}

--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -93,6 +93,12 @@ public class LPRTableView: UITableView {
 	
 }
 
+extension LPRTableView: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return draggingView == nil
+    }
+}
+
 extension LPRTableView {
 	
 	private func canMoveRowAt(indexPath indexPath: NSIndexPath) -> Bool {

--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -56,15 +56,19 @@ public class LPRTableView: UITableView {
     {
         if draggingView != nil
         {
-            self.scrollDisplayLink?.invalidate()
-            self.scrollDisplayLink = nil
-            self.scrollRate = 0.0
+            scrollDisplayLink?.invalidate()
+            scrollDisplayLink = nil
+            scrollRate = 0.0
             
-            self.draggingView?.removeFromSuperview()
-            self.draggingView = nil
-            self.currentLocationIndexPath = nil
+            draggingView?.removeFromSuperview()
+            draggingView = nil
             
-            self.reloadData()
+            if let clIndexPath = currentLocationIndexPath
+            {
+                cellForRowAtIndexPath(clIndexPath)?.hidden = false
+            }
+            
+            currentLocationIndexPath = nil
         }
     }
 	

--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -248,6 +248,8 @@ extension LPRTableView {
 				let oldHeight = rectForRowAtIndexPath(clIndexPath).size.height
 				let newHeight = rectForRowAtIndexPath(indexPath).size.height
 				
+                cellForRowAtIndexPath(clIndexPath)?.hidden = true
+                
 				if ((indexPath != clIndexPath) &&
 					(gesture.locationInView(cellForRowAtIndexPath(indexPath)).y > (newHeight - oldHeight))) &&
 					canMoveRowAt(indexPath: indexPath) {

--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -95,7 +95,11 @@ public class LPRTableView: UITableView {
 
 extension LPRTableView: UIGestureRecognizerDelegate {
     public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return draggingView == nil
+        if !gestureRecognizer.isKindOfClass(UILongPressGestureRecognizer) && !otherGestureRecognizer.isKindOfClass(UILongPressGestureRecognizer) {
+            return false
+        } else {
+            return draggingView == nil
+        }
     }
 }
 

--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -56,16 +56,12 @@ public class LPRTableView: UITableView {
 		self.init(frame: CGRectZero)
 	}
 	
-	public convenience override init(frame: CGRect) {
-		self.init(frame: frame, style: .Plain)
-	}
-	
 	public override init(frame: CGRect, style: UITableViewStyle) {
 		super.init(frame: frame, style: style)
 		initialize()
 	}
 	
-	public required init(coder aDecoder: NSCoder) {
+	public required init?(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 		initialize()
 	}
@@ -79,7 +75,7 @@ public class LPRTableView: UITableView {
 
 extension LPRTableView {
 	
-	private func canMoveRowAt(#indexPath: NSIndexPath) -> Bool {
+	private func canMoveRowAt(indexPath indexPath: NSIndexPath) -> Bool {
 		return (dataSource?.respondsToSelector("tableView:canMoveRowAtIndexPath:") == false) || (dataSource?.tableView?(self, canMoveRowAtIndexPath: indexPath) == true)
 	}
 	
@@ -93,7 +89,7 @@ extension LPRTableView {
 		let location = gesture.locationInView(self)
 		let indexPath = indexPathForRowAtPoint(location)
 		
-		let sections = numberOfSections()
+		let sections = numberOfSections
 		var rows = 0
 		for i in 0..<sections {
 			rows += numberOfRowsInSection(i)
@@ -125,13 +121,13 @@ extension LPRTableView {
 						
 						// Make an image from the pressed table view cell.
 						UIGraphicsBeginImageContextWithOptions(cell.bounds.size, false, 0.0)
-						cell.layer.renderInContext(UIGraphicsGetCurrentContext())
-						var cellImage = UIGraphicsGetImageFromCurrentImageContext()
+						cell.layer.renderInContext(UIGraphicsGetCurrentContext()!)
+						let cellImage = UIGraphicsGetImageFromCurrentImageContext()
 						UIGraphicsEndImageContext()
 						
 						draggingView = UIImageView(image: cellImage)
 						
-						if var draggingView = draggingView {
+						if let draggingView = draggingView {
 							addSubview(draggingView)
 							let rect = rectForRowAtIndexPath(indexPath)
 							draggingView.frame = CGRectOffset(draggingView.bounds, rect.origin.x, rect.origin.y)
@@ -169,7 +165,7 @@ extension LPRTableView {
 		// Dragging.
 		else if gesture.state == .Changed {
 			
-			if var draggingView = draggingView {
+			if let draggingView = draggingView {
 				// Update position of the drag view,
 				// but don't let it go past the top or the bottom too far.
 				if (location.y >= 0.0) && (location.y <= contentSize.height + 50.0) {
@@ -211,7 +207,7 @@ extension LPRTableView {
 			// Animate the drag view to the newly hovered cell.
 			UIView.animateWithDuration(0.3,
 				animations: { [unowned self] in
-					if var draggingView = self.draggingView {
+					if let draggingView = self.draggingView {
 						if let currentLocationIndexPath = self.currentLocationIndexPath {
 							UIView.beginAnimations("LongPressReorder-HideDraggingView", context: nil)
 							self.longPressReorderDelegate?.tableView?(self, hideDraggingView: draggingView, atIndexPath: currentLocationIndexPath)
@@ -223,12 +219,12 @@ extension LPRTableView {
 					}
 				},
 				completion: { [unowned self] (finished: Bool) in
-					if var draggingView = self.draggingView {
+					if let draggingView = self.draggingView {
 						draggingView.removeFromSuperview()
 					}
 					
 					// Reload the rows that were affected just to be safe.
-					if let visibleRows = self.indexPathsForVisibleRows() {
+					if let visibleRows = self.indexPathsForVisibleRows {
 						self.reloadRowsAtIndexPaths(visibleRows, withRowAnimation: .None)
 					}
 					
@@ -313,7 +309,7 @@ public class LPRTableViewController: UITableViewController, LPRTableViewDelegate
 		initialize()
 	}
 	
-	public required init(coder aDecoder: NSCoder) {
+	public required init?(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 		initialize()
 	}

--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -51,6 +51,22 @@ public class LPRTableView: UITableView {
 		longPressGestureRecognizer.enabled = newValue
 	}
 	}
+    
+    public func endDragging()
+    {
+        if draggingView != nil
+        {
+            self.scrollDisplayLink?.invalidate()
+            self.scrollDisplayLink = nil
+            self.scrollRate = 0.0
+            
+            self.draggingView?.removeFromSuperview()
+            self.draggingView = nil
+            self.currentLocationIndexPath = nil
+            
+            self.reloadData()
+        }
+    }
 	
 	public convenience init()  {
 		self.init(frame: CGRectZero)

--- a/ReorderTest/ReorderTest/MasterViewController.swift
+++ b/ReorderTest/ReorderTest/MasterViewController.swift
@@ -22,7 +22,7 @@ class MasterViewController: LPRTableViewController {
 		
 		// Do any additional setup after loading the view, typically from a nib.
 		navigationItem.leftBarButtonItem = self.editButtonItem()
-		navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Add, target: self, action: "insertNewObject:")
+		navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Add, target: self, action: #selector(MasterViewController.insertNewObject(_:)))
 	}
 	
 	override func didReceiveMemoryWarning() {


### PR DESCRIPTION
When the dragging cell is moved so fast there was a problem where the cell in the table view is not hidden. In my app this line of code resolved the issue.

Any ideas?
