### PR TITLE
Deleted unneeded import statement

### DIFF
--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -6,7 +6,6 @@
 //  Swift adaptation Copyright (c) 2014 Nicolas Gomollon. All rights reserved.
 //
 
-import Foundation
 import QuartzCore
 import UIKit
 


### PR DESCRIPTION
The `import UIKit` statement already imports `Foundation` so we can delete the extra import statement.